### PR TITLE
show error modal when popup is blocked

### DIFF
--- a/src/web/html/assets/js/alaska_main.js
+++ b/src/web/html/assets/js/alaska_main.js
@@ -5204,7 +5204,19 @@ function parse_sleuth_server(out, btn, spinner, width) {
     btn.width(width);
 
     var url = 'http://' + window.location.hostname + ':' + port + '/';
-    window.open(url, '_blank');
+    var win = window.open(url, '_blank');
+
+    // Check if popup has been blocked. If it has, notify the user
+    // to allow popups, or to click on a link that will direct them to the
+    // sleuth page.
+    if (win == null || typeof(win) == 'undefined') {
+      var modal = $('#popup_modal');
+      url_element = modal.find('#sleuth_url');
+      url_element.text(url);
+      url_element.attr('href', url);
+
+      modal.modal('show');
+    }
   }
 
   if (out.includes('already open')) {

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -2726,7 +2726,41 @@
                   id="refetch_reads_btn_2">Re-fetch reads</button></div>
       </div>
     </div>
-  </div><!-- Generic error message div -->
+  </div>
+  <!-- Popup bocked error message modal. -->
+  <div class="modal fade"
+       id="popup_modal"
+       tabindex="-1"
+       role="dialog"
+       data-backdrop="static"
+       data-keyboard="false">
+    <div class="modal-dialog"
+         role="document">
+      <div class="modal-content">
+        <div class="modal-header alert-warning">
+          <h5 class="modal-title">
+            <i class="fas fa-exclamation-triangle"></i>
+            Popup blocked!
+          </h5>
+        </div>
+        <div class="modal-body text-dark">
+          <p>
+            Alaska attempted to open a new webpage to display the Sleuth
+            web server, but the popup was blocked your browser. Please
+            enable popups and try again, or click on the link below to access
+            Sleuth.
+          </p>
+          <a id="sleuth_url" target='_blank'></a>
+        </div>
+        <div class="modal-footer">
+          <button type="button"
+                  class="btn btn-secondary"
+                  data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Generic error message div -->
   <div class="modal fade"
        id="error_modal"
        tabindex="-1"


### PR DESCRIPTION
As mentioned in #27, there were issues with browsers blocking popups when Alaska tries to open a browser tab for the Sleuth web server. A new modal was added to the HTML to notify the user that a popup has been blocked and to either enable popups or manually click on the link to the Sleuth server.