### PR TITLE
Fix tarball creation of entire project

### DIFF
--- a/src/scripts/AlaskaProject.py
+++ b/src/scripts/AlaskaProject.py
@@ -283,6 +283,10 @@ class AlaskaProject(Alaska):
 
         Returns: None
         """
+        # Write the SOFT format seq_info.txt
+        out = 'seq_info.txt'
+        self.write_soft(out)
+
         # Make a new archive.
         geo_arch = '{}/{}'.format(self.dir, Alaska.GEO_ARCH)
         with tarfile.open(geo_arch, 'w:gz') as tar:
@@ -308,10 +312,6 @@ class AlaskaProject(Alaska):
                     full_path = '{}/{}'.format(self.diff_dir, file)
                     arcname = file
                     tar.add(full_path, arcname=arcname)
-
-            # Then, write the SOFT format seq_info.txt
-            out = 'seq_info.txt'
-            self.write_soft(out)
 
             # Add the softfile.
             full_path = '{}/{}'.format(self.dir, out)

--- a/src/scripts/AlaskaServer.py
+++ b/src/scripts/AlaskaServer.py
@@ -1066,7 +1066,7 @@ class AlaskaServer(Alaska):
         datetime = (dt.datetime.now().strftime(Alaska.DATETIME_FORMAT)
                     + ' Pacific Time')
         url = 'http://alaska.caltech.edu:81/?id=' + _id
-        fr = 'noreply@alaska.caltech.edu'
+        fr = '{}@alaska.caltech.edu'.format(_id)
 
         # Footer that is appended to every email.
         if _id in self.ftp:

--- a/src/scripts/AlaskaServer.py
+++ b/src/scripts/AlaskaServer.py
@@ -1083,7 +1083,8 @@ class AlaskaServer(Alaska):
                  FTP port: 21<br> \
                  FTP username: {}<br> \
                  FTP password: {}<br> \
-                 This message was sent to {} at {}.</p> \
+                 This message was sent to {} at {}.<br> \
+                 <b>Please do not reply to this email.</b></p> \
                 </body> \
             </html> \
             '.format(msg, _id, url, url, _id, self.ftp[_id], to, datetime)
@@ -1097,7 +1098,8 @@ class AlaskaServer(Alaska):
                  <hr> \
                  <p>Project ID: {}<br> \
                  Unique URL: <a href="{}">{}</a><br> \
-                 This message was sent to {} at {}.</p> \
+                 This message was sent to {} at {}.<br> \
+                 <b>Please do not reply to this email.</b></p> \
                 </body> \
             </html> \
             '.format(msg, _id, url, url, to, datetime)

--- a/src/scripts/run_analysis.py
+++ b/src/scripts/run_analysis.py
@@ -102,7 +102,7 @@ def archive(out, source_dir):
             tar.add(source_dir, arcname=os.path.sep)
         else:
             for d in source_dir:
-                tar.add(d, arcname=os.path.sep)
+                tar.add(d, arcname=d)
 
 ######### These functions must be here to allow multiprocessing.
 def read_distribution(_id, bed_path):
@@ -459,7 +459,7 @@ def run_sleuth(proj):
     print_with_flush('# all analyses finished, archiving entire project')
     dirs_to_archive = []
     for d in os.listdir():
-        if d != '_temp' and d != '0_raw_reads' and not d.endswith('.tar.gz'):
+        if os.path.isdir(d) and d not in ['_temp', '0_raw_reads']:
             dirs_to_archive.append(d)
     archive(proj['id'] + '.tar.gz', dirs_to_archive)
     print_with_flush('# done')

--- a/src/scripts/run_analysis.py
+++ b/src/scripts/run_analysis.py
@@ -100,9 +100,9 @@ def archive(out, source_dir):
     with tarfile.open(out, 'w:gz') as tar:
         if isinstance(source_dir, str):
             tar.add(source_dir, arcname=os.path.sep)
-        else:
+        elif isinstance(source_dir, list):
             for d in source_dir:
-                tar.add(d, arcname=d)
+                tar.add(d)
 
 ######### These functions must be here to allow multiprocessing.
 def read_distribution(_id, bed_path):

--- a/src/web/html/assets/js/alaska_main.js
+++ b/src/web/html/assets/js/alaska_main.js
@@ -502,7 +502,7 @@ function set_progress(status) {
     set_progress_badge(elements.diff_status_badge, 'queued');
     set_progress_bar_quant();
   } else {
-    st_progress_bar_diff();
+    set_progress_bar_diff();
   }
 
   if (status >= progress.diff_finished) {


### PR DESCRIPTION
This refers to the tar.gz file downloaded when the user clicks "Download all results" in the analysis results page. A typo in the run_analysis.py script caused all the analysis files to be added to the root of the archive, when they should have in fact been in their own folders. This (and a typo in alaska_main.js) was fixed. The tar.gz generated by Alaska can be unarchived without any more errors.